### PR TITLE
Thicker lines

### DIFF
--- a/ublue.mplstyle
+++ b/ublue.mplstyle
@@ -35,3 +35,5 @@ savefig.facecolor: FFFFFF
 
 # grid: grey
 grid.color: CCCCCC
+
+lines.linewidth: 5


### PR DESCRIPTION
Thicker lines like Jorge suggested on Discord.

I set it to 5 and it looks like this
![growth_global](https://github.com/user-attachments/assets/6f615bba-8191-45e1-9736-c78ccdd839b9)

For reference, with the current value it looks like this
![growth_global](https://github.com/user-attachments/assets/f466b689-9bd5-499f-aff2-68c4531187b2)

Maybe it's too much?

This is with thickness at 4
![growth_global4](https://github.com/user-attachments/assets/c15c9328-00a6-4993-bc4b-1758e8e2defd)

This is at 3
![growth_global3](https://github.com/user-attachments/assets/9ab20fa9-bf44-493d-8b69-bd9ecf114f92)