### PR TITLE
Use orange for Bluefin LTS (note this is the same as Aurora)

### DIFF
--- a/countme.py
+++ b/countme.py
@@ -16,7 +16,7 @@ colors = {
     "Silverblue" :         Light[5][4], # Light blue
     "Aurora" :             Light[5][1], # Orange
     "Kinoite" :            Light[5][2], # Light orange
-    "Bluefin LTS":         Light[7][6], # Light green
+    "Bluefin LTS":         Light[7][1], # Orange
     "Aurora Helium (LTS)": Light[7][5], # Green
 }
 


### PR DESCRIPTION
Change Bluefin LTS to orange
![image](https://github.com/user-attachments/assets/dff921de-941a-4b6f-a6cd-03bd938055de)

This way the `growth_ublue_lts.svg` graph becomes unusable tho!
![image](https://github.com/user-attachments/assets/28276f9c-057f-4b78-a86d-53d2c4295b0c)

If you don't think you'll need this graph then it's all good