### PR TITLE
Update .gitignore to revert *.svg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.csv*
 venv
 *.png
-*.svg


### PR DESCRIPTION
This line was added a few weeks ago by me. I regret this, because adding new SVGs is a PITA now (only existing ones can be updated in the repo). I'd like to revert this change, to unfreeze the total amount of SVGs created. 

Mainly to get the upstream_growth.svg chart (which we're calculating but not committing) on the repo, for those who are curious.