### PR TITLE
feat: add badge data generation

### DIFF
--- a/.github/workflows/countme.yml
+++ b/.github/workflows/countme.yml
@@ -34,6 +34,7 @@ jobs:
               growth_bazzite_purple.svg
               growth_global.svg
               growth_ublue_lts.svg
-              growth_upstream.svg 
+              growth_upstream.svg
+              badge-endpoints/*.json
             commit-msg: Growth Chart Update ${{ steps.date.outputs.date }}
             github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # countme
-countme 
-
 
 ## How to run locally
 
@@ -14,3 +12,42 @@ pip install -r requirements.txt
 ```
 
 Comment out `wget` line on graph.sh after first run if you don't want to re-download dataset every time (only changes once per day).
+
+## Badge System
+
+This repository generates Shield.io compatible badge endpoints that display active user counts for Universal Blue projects. Add user count badges to your repository using these Shield.io endpoint URLs:
+
+### Available Badges
+
+- **Bazzite**: ![Bazzite Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bazzite.json)
+- **Bluefin**: ![Bluefin Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json)
+- **Aurora**: ![Aurora Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/aurora.json)
+
+### Markdown Code
+
+Add these to your README.md:
+
+```markdown
+![Bazzite Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bazzite.json)
+![Bluefin Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json)
+![Aurora Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/aurora.json)
+```
+
+## Badge Data Format
+
+The system generates Shield.io compatible endpoint files:
+- `badge-endpoints/bazzite.json`
+- `badge-endpoints/bluefin.json`
+- `badge-endpoints/aurora.json`
+
+Each file contains:
+```json
+{
+  "schemaVersion": 1,
+  "label": "Active Users",
+  "message": "15.2k",
+  "color": "6c3fc4",
+  "namedLogo": "linux",
+  "logoColor": "white"
+}
+```

--- a/generate_badge_data.py
+++ b/generate_badge_data.py
@@ -1,0 +1,174 @@
+import pandas as pd
+import numpy as np
+import json
+import datetime
+import os
+from dateutil.relativedelta import relativedelta
+
+def load_and_process_data():
+    orig = pd.read_csv(
+        "totals.csv",
+        usecols=["week_end", "repo_tag", "os_variant", "hits", "os_name", "sys_age"],
+        parse_dates=["week_end"],
+        dtype={
+            "repo_tag": "object",
+            "os_variant": "category",
+            "os_name": "category",
+        },
+    )
+
+    # Filter for systems older than 1 week (active users)
+    orig = orig[orig["sys_age"] >= 1]
+
+    # Filter bad dates
+    orig = orig[
+        (orig["week_end"] != pd.to_datetime("2024-12-29"))
+    ]
+
+    # Get recent data (last 9 months)
+    START_DATE = datetime.datetime.now() - relativedelta(months=9)
+    orig = orig[orig["week_end"] >= START_DATE]
+
+    # Filter for Fedora repos
+    d = orig[
+        orig["repo_tag"].isin([f"fedora-{v}" for v in range(30, 45)])
+    ]
+
+    return d, orig
+
+def calculate_os_hits(d, orig):
+    """Calculate hits for each OS."""
+    os_list = [
+        "Silverblue", "Kinoite", "Bluefin", "Bazzite", "Aurora", "uCore",
+        "Workstation", "Server", "KDE Plasma", "CoreOS", "IoT"
+    ]
+
+    # Create dataframe with one row per week, one column per OS
+    os_hits = pd.DataFrame()
+
+    for os in os_list:
+        mask = d["os_variant"].str.lower().str.contains(os.lower(), na=False)
+        res = d[mask].groupby("week_end")["hits"].sum()
+        os_hits[os] = res
+
+    # Handle LTS variants separately using os_name
+
+    # Aurora LTS hits
+    aurora_lts_alt_name_hits = pd.DataFrame(index=os_hits.index)
+    for alt_name in ["Aurora Helium (LTS)", "Aurora Helium", "Aurora LTS"]:
+        mask = orig["os_name"] == alt_name
+        res = orig[mask].groupby("week_end")["hits"].sum()
+        aurora_lts_alt_name_hits[alt_name] = res
+
+    os_hits["Aurora Helium (LTS)"] = aurora_lts_alt_name_hits.sum(axis=1, min_count=1)
+
+    # Bluefin LTS hits
+    bluefin_lts_alt_name_hits = pd.DataFrame(index=os_hits.index)
+    for alt_name in ["Achillobator", "Bluefin LTS"]:
+        mask = orig["os_name"] == alt_name
+        res = orig[mask].groupby("week_end")["hits"].sum()
+        bluefin_lts_alt_name_hits[alt_name] = res
+
+    os_hits["Bluefin LTS"] = bluefin_lts_alt_name_hits.sum(axis=1, min_count=1)
+
+    # Fedora KDE hits
+    fedora_kde_hits = pd.DataFrame(index=os_hits.index)
+    for alt_name in ["Fedora Linux"]:
+        mask = (orig["os_name"] == alt_name) & (orig["os_variant"] == "kde")
+        res = orig[mask].groupby("week_end")["hits"].sum()
+        fedora_kde_hits[alt_name] = res
+
+    os_hits["KDE Plasma"] = fedora_kde_hits.sum(axis=1, min_count=1)
+
+    return os_hits
+
+def format_count(count):
+    """Format count for badge display."""
+    if pd.isna(count) or count == 0:
+        return "0"
+    elif count < 1000:
+        return str(int(count))
+    elif count < 10000:
+        return f"{count/1000:.1f}k"
+    else:
+        return f"{int(count/1000)}k"
+
+def generate_badge_data(os_hits):
+    """Generate Shield.io endpoint files for each project."""
+    print("Generating badge data...")
+
+    # Get the most recent week's data
+    latest_data = os_hits.iloc[-1]
+
+    # Create badge-endpoints directory
+    os.makedirs("badge-endpoints", exist_ok=True)
+
+    # Define project mappings
+    project_mappings = {
+        "bazzite": {
+            "name": "Bazzite",
+            "os_variants": ["Bazzite"],
+            "color": "6c3fc4"
+        },
+        "bluefin": {
+            "name": "Bluefin",
+            "os_variants": ["Bluefin", "Bluefin LTS"],
+            "color": "0066cc"
+        },
+        "aurora": {
+            "name": "Aurora",
+            "os_variants": ["Aurora", "Aurora Helium (LTS)"],
+            "color": "ff6600"
+        }
+    }
+
+    generated_projects = []
+
+    for project_key, project_info in project_mappings.items():
+        # Calculate total users for this project
+        total_users = 0
+        for variant in project_info["os_variants"]:
+            if variant in latest_data and not pd.isna(latest_data[variant]):
+                total_users += latest_data[variant]
+
+        # Format user count for display
+        users_formatted = format_count(total_users)
+
+        # Create Shield.io endpoint data
+        endpoint_data = {
+            "schemaVersion": 1,
+            "label": "Active Users",
+            "message": users_formatted,
+            "color": project_info["color"],
+            "namedLogo": "linux",
+            "logoColor": "white"
+        }
+
+        # Write endpoint file
+        with open(f"badge-endpoints/{project_key}.json", "w") as f:
+            json.dump(endpoint_data, f, indent=2)
+
+        generated_projects.append({
+            "name": project_info["name"],
+            "users_formatted": users_formatted,
+            "file": f"{project_key}.json"
+        })
+
+        print(f"Generated endpoint for {project_info['name']}: {users_formatted} users")
+
+    return generated_projects
+
+def main():
+        d, orig = load_and_process_data()
+        os_hits = calculate_os_hits(d, orig)
+
+        generated_projects = generate_badge_data(os_hits)
+
+        print(f"Generated {len(generated_projects)} project badges:")
+
+        for project in generated_projects:
+            print(f"  {project['name']}: {project['users_formatted']} users -> {project['file']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/graph.sh
+++ b/graph.sh
@@ -5,3 +5,4 @@ pip3 install -r requirements.txt
 wget https://data-analysis.fedoraproject.org/csv-reports/countme/totals.csv
 
 python3 countme.py
+python3 generate_badge_data.py


### PR DESCRIPTION
This PR generates Shield.io compatible badge endpoints that display active user counts for Universal Blue OSes.

- ![Bazzite Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ledif/countme/main/badge-endpoints/bazzite.json&label=Bazzite)
- ![Bluefin Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ledif/countme/main/badge-endpoints/bluefin.json&label=Bluefin)
- ![Aurora Users](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ledif/countme/main/badge-endpoints/aurora.json&label=Aurora)

